### PR TITLE
Updated build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif (DOXYGEN_FOUND)
 
 # clang-tidy target (linter & static code analysis)
 add_custom_target(clang-tidy
-  COMMAND CMAKE_EXPORT_COMPILE_COMMANDS=ON run-clang-tidy-3.8.py ${CMAKE_CURRENT_SOURCE_DIR})
+  COMMAND CMAKE_EXPORT_COMPILE_COMMANDS=ON run-clang-tidy ${CMAKE_CURRENT_SOURCE_DIR})
 
 # clang-format
 set(ALL_SOURCE_FILES
@@ -78,6 +78,9 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+
++# Creates compile database used by clang-tidy.
++set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 include_directories(
   include


### PR DESCRIPTION
 - Added Debug and Release modes:
    - Debug uses `clang++`, as it provides faster build times and far better error messages.
    - Release uses `g++`, as historically `g++` has produced faster binaries (though this is worth looking into further, LLVM has gotten very good).
 - Fixed `clang-tidy` target.
    - Fixed target's invocation to use the generic version, `run-clang-tidy`.
    - Added command to automatically generate the compile database for `clang-tidy`'s use.
 - Replaced the file list with extension based globs to make future file additions easier to manage.
 - Updated README.md with instructions on how to build both modes.