### PR TITLE
= to in fix in standard benchmark converter

### DIFF
--- a/example/standard_benchmark_converter.py
+++ b/example/standard_benchmark_converter.py
@@ -43,7 +43,7 @@ def load_map_file(map_file, occupied_char={'@', 'T', 'O'}, valid_chars={'@', '.'
         assert(len(l) == width)
         for x, c in enumerate(l):
             assert(c in valid_chars)
-            if c == occupied_char:
+            if c in occupied_char:
                 occupancy_lst.add((x, y))
     return width, height, occupancy_lst
 


### PR DESCRIPTION
Latest change to the converter breaks load_map_file because type of occupied_char is changed to set from string.